### PR TITLE
Remove deprecation warnings for include statement

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Install influxdb
-  include: "install-{{ ansible_os_family|lower }}.yml"
+  include_tasks: "install-{{ ansible_os_family|lower }}.yml"
 
 - name: Get influxdb user info
   user: name=influxdb


### PR DESCRIPTION
Just a follow up to avoid deprecation warnings and role failing with next Ansible release

Thanks,

Ludo